### PR TITLE
Added disabled inviteUsersCheckList feature flag

### DIFF
--- a/src/app/pages/add-hub/add-hub.page.html
+++ b/src/app/pages/add-hub/add-hub.page.html
@@ -87,11 +87,11 @@
 
       </ion-item>
 
-      <ion-list-header class="ion-padding-bottom">
+      <ion-list-header [appFeatureFlag]="'inviteUsersCheckList'" class="ion-padding-bottom">
         <ion-text>Invite People</ion-text>
       </ion-list-header>
 
-      <ion-item *ngFor="let person of persons | async">
+      <ion-item [appFeatureFlag]="'inviteUsersCheckList'" *ngFor="let person of persons | async">
         <ion-avatar slot="start">
           <img width="100%" [appFeatureFlag]="'adorableAvatarsUserImage'" *ngIf="!person.image"
             src="{{person.id | avatar}}">

--- a/src/app/pages/hub/invite/invite.page.html
+++ b/src/app/pages/hub/invite/invite.page.html
@@ -26,12 +26,12 @@
       </p>
     </ion-text>
 
-    <ion-list *ngIf="!loading">
+    <ion-list [appFeatureFlag]="'inviteUsersCheckList'" *ngIf="!loading">
       <ion-list-header class="ion-padding-bottom">
         People
       </ion-list-header>
 
-      <ion-item *ngFor="let person of persons | async">
+      <ion-item [appFeatureFlag]="'inviteUsersCheckList'" *ngFor="let person of persons | async">
         <ion-avatar slot="start">
           <img width="100%" [appFeatureFlag]="'adorableAvatarsUserImage'" *ngIf="!person.image"
             src="{{person.id | avatar}}">

--- a/src/environments/environment.demo.ts
+++ b/src/environments/environment.demo.ts
@@ -119,7 +119,8 @@ export const environment: Environment = {
     adorableAvatarsUserImage: true,
     uberRequestRide: true,
     microChat: false,
-    lightDarkThemeToggle: false
+    lightDarkThemeToggle: false,
+    inviteUsersCheckList: false
   },
   logging: {
     level: NgxLoggerLevel.DEBUG,

--- a/src/environments/environment.interface.ts
+++ b/src/environments/environment.interface.ts
@@ -20,7 +20,8 @@ export interface Environment {
       adorableAvatarsUserImage: boolean,
       uberRequestRide: boolean,
       microChat: boolean,
-      lightDarkThemeToggle: boolean
+      lightDarkThemeToggle: boolean,
+      inviteUsersCheckList: boolean,
     };
     logging: LoggerConfig;
     backgroundGeoLocationConfig: BackgroundGeolocationConfig;

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -21,7 +21,8 @@ export const environment: Environment = {
     adorableAvatarsUserImage: true,
     uberRequestRide: true,
     microChat: false,
-    lightDarkThemeToggle: false
+    lightDarkThemeToggle: false,
+    inviteUsersCheckList: false
   },
   logging: {
     level: NgxLoggerLevel.DEBUG,

--- a/src/environments/environment.staging.ts
+++ b/src/environments/environment.staging.ts
@@ -21,7 +21,8 @@ export const environment: Environment = {
     adorableAvatarsUserImage: true,
     uberRequestRide: true,
     microChat: true,
-    lightDarkThemeToggle: false
+    lightDarkThemeToggle: false,
+    inviteUsersCheckList: false
   },
   logging: {
     level: NgxLoggerLevel.DEBUG,

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -25,7 +25,8 @@ export const environment: Environment = {
     adorableAvatarsUserImage: true,
     uberRequestRide: true,
     microChat: false,
-    lightDarkThemeToggle: false
+    lightDarkThemeToggle: false,
+    inviteUsersCheckList: false
   },
   logging: {
     level: NgxLoggerLevel.DEBUG,


### PR DESCRIPTION
This is to hide the incomplete invite user checklist on the create hub & the invite pages. The UI is stubbed though not actually functional. This work shall be completed in the ticket below:
- https://github.com/Lazztech/Lazztech.Hub-App/issues/10

This MR simply disables the incomplete stubbed ui users checklists for future completion & re-enabling of this feature.