### PR TITLE
Bug: Hub page map showing users location, not the hub location #18

### DIFF
--- a/src/app/components/hub-card/hub-card.component.html
+++ b/src/app/components/hub-card/hub-card.component.html
@@ -63,6 +63,6 @@
 
   </ion-card-content>
   <div *ngIf="includeMap" style="height: 90px;">
-      <app-leaflet-map *ngIf="coords" [center]="coords"></app-leaflet-map>
+      <app-leaflet-map *ngIf="coords" [center]="hub"></app-leaflet-map>
   </div>
 </ion-card>


### PR DESCRIPTION
Ticket
- https://github.com/Lazztech/Lazztech.Hub-App/issues/18

The objective of this PR is to fix the hub card's map to show the hub's location instead of the user's location. The images below it show that the add-hub page still shows the user's location while the hub pages now show the location of the hub correctly.

![IMG_7540](https://user-images.githubusercontent.com/1166579/146268779-0d53ca5b-20a0-466d-af3e-8e055dcde36c.PNG)

![IMG_7539](https://user-images.githubusercontent.com/1166579/146268774-ba6e1d1d-edfe-41e3-abd0-4abfe5e61b3c.PNG)